### PR TITLE
Fixed exception when calling update_keyboard_mapping.

### DIFF
--- a/xpybutil/keybind.py
+++ b/xpybutil/keybind.py
@@ -476,7 +476,7 @@ def __regrab(changes):
     :type changes: dict
     :rtype: void
     """
-    for wid, mods, kc in __keybinds:
+    for wid, mods, kc in __keybinds.keys():
         if kc in changes:
             ungrab_key(wid, mods, kc)
             grab_key(wid, mods, changes[kc])


### PR DESCRIPTION
When calling `update_keyboard_mapping`, if the set of changes included any keys that were currently bound, `__regrab` would cause an exception:
```python
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/zmq/eventloop/ioloop.py", line 440, in _run_callback
    callback()
  File "/home/whitelynx/devel/personal/fttpwm/fttpwm/x.py", line 153, in updateKeyboardMapping
    xpybutil.keybind.update_keyboard_mapping(self.pendingUpdateKeyboardMapping)
  File "/usr/lib/python2.7/site-packages/xpybutil/keybind.py", line 442, in update_keyboard_mapping
    __regrab(changes)
  File "/usr/lib/python2.7/site-packages/xpybutil/keybind.py", line 479, in __regrab
    for wid, mods, kc in __keybinds:
RuntimeError: dictionary changed size during iteration
```

This patch fixes the exception, but unfortunately, `update_keyboard_mapping` sometimes still doesn't correctly re-bind keys whose mappings have changed. (I'm still tracking that down)