### PR TITLE
Update for Python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ from distutils.core import setup
 try:
     import xcb.xproto, xcb.xcb, xcb.xinerama, xcb.randr
 except:
-    print ''
-    print 'xpybutil requires the X Python Binding'
-    print 'See: http://cgit.freedesktop.org/xcb/xpyb/'
-    print 'Or xpyb-ng can be used. See', 'https://github.com/dequis/xpyb-ng'
+    print ('')
+    print ('xpybutil requires the X Python Binding')
+    print ('See: http://cgit.freedesktop.org/xcb/xpyb/')
+    print ('Or xpyb-ng can be used. See', 'https://github.com/dequis/xpyb-ng')
     sys.exit(1)
 
 setup(

--- a/xpybutil/event.py
+++ b/xpybutil/event.py
@@ -11,8 +11,7 @@ import traceback
 import xcb
 import xcb.xproto as xproto
 
-from xpybutil import conn, root
-import util
+from xpybutil import conn, root, util
 
 __queue = deque()
 __callbacks = defaultdict(list)
@@ -64,6 +63,10 @@ def send_event_checked(destination, event_mask, event, propagate=False):
     return conn.core.SendEventChecked(propagate, destination, event_mask, event)
 
 def pack_client_message(window, message_type, *data):
+
+    if sys.version_info[0] >= 3:
+        basestring = str
+
     assert len(data) <= 5
 
     if isinstance(message_type, basestring):

--- a/xpybutil/ewmh.py
+++ b/xpybutil/ewmh.py
@@ -74,9 +74,7 @@ import struct
 
 import xcb.xproto
 
-from xpybutil import conn as c, root
-import event
-import util
+from xpybutil import conn as c, root, event, util
 
 __atoms = [
    # Non-standard

--- a/xpybutil/keybind.py
+++ b/xpybutil/keybind.py
@@ -12,9 +12,8 @@ import sys
 
 import xcb.xproto as xproto
 
-from xpybutil import conn, root
-import event
-from keysymdef import keysyms, keysym_strings
+from xpybutil import conn, root, event
+from xpybutil.keysymdef import keysyms, keysym_strings
 
 __kbmap = None
 __keysmods = None
@@ -233,8 +232,8 @@ def get_keycode(keysym):
     """
     mn, mx = get_min_max_keycode()
     cols = __kbmap.keysyms_per_keycode
-    for i in xrange(mn, mx + 1):
-        for j in xrange(0, cols):
+    for i in range(mn, mx + 1):
+        for j in range(0, cols):
             ks = get_keysym(i, col=j)
             if ks == keysym:
                 return i
@@ -283,7 +282,7 @@ def get_keys_to_mods():
 
     res = {}
     keyspermod = mods.keycodes_per_modifier
-    for mmi in xrange(0, len(modmasks)):
+    for mmi in range(0, len(modmasks)):
         row = mmi * keyspermod
         for kc in mods.keycodes[row:row + keyspermod]:
             res[kc] = modmasks[mmi]
@@ -432,7 +431,7 @@ def update_keyboard_mapping(e):
 
     if e.request == xproto.Mapping.Keyboard:
         changes = {}
-        for kc in xrange(*get_min_max_keycode()):
+        for kc in range(*get_min_max_keycode()):
             knew = get_keysym(kc, kbmap=newmap)
             oldkc = get_keycode(knew)
             if oldkc != kc:

--- a/xpybutil/keysymdef.py
+++ b/xpybutil/keysymdef.py
@@ -2019,6 +2019,5 @@ keysyms = {
 }
 
 keysym_strings = defaultdict(list)
-for keysym_string, keysym in keysyms.iteritems():
+for keysym_string, keysym in keysyms.items():
     keysym_strings[keysym].append(keysym_string)
-

--- a/xpybutil/util.py
+++ b/xpybutil/util.py
@@ -168,7 +168,7 @@ def build_atom_cache(atoms):
         if isinstance(__atom_cache[atom], AtomCookie):
             __atom_cache[atom] = __atom_cache[atom].reply()
 
-    __atom_nm_cache = dict((v, k) for k, v in __atom_cache.iteritems())
+    __atom_nm_cache = dict((v, k) for k, v in __atom_cache.items())
 
 def get_atom(atom_name, only_if_exists=False):
     """
@@ -226,8 +226,9 @@ def __get_atom_cookie(atom_name, only_if_exists=False):
     :type only_if_exists: bool
     :rtype: xcb.xproto.InternAtomCookie
     """
-    atom = conn.core.InternAtomUnchecked(only_if_exists, len(atom_name),
-                                         atom_name)
+    atom_bytes = atom_name.encode('ascii')
+    atom = conn.core.InternAtomUnchecked(only_if_exists, len(atom_bytes),
+                                         atom_bytes)
     return AtomCookie(atom)
 
 def __get_atom_name_cookie(atom):


### PR DESCRIPTION
This patch updates xpybutil to be compatible with both Python 2 and 3.

Some notes:
- I converted xrange() to range(), and iteritems() to items(), without conditionalizing for Python 2/3.  It seemed that in all cases the data involved was small enough to not be worth adding extra complexity to handle the difference.
- I use encode('ascii') to encode atom names before sending for both Python 2 and 3.  I used ascii and not utf-8 so that it would generate an error if the string isn't ASCII.  I could have gone to more effort to avoid a string operation on Python 2, but didn't think it was worth it.

I'm happy to address either of these notes differently if you have a preference, but figured I'd throw out an initial patch as a suggestion to see what you think.  Thanks!